### PR TITLE
Added logger

### DIFF
--- a/.env-template
+++ b/.env-template
@@ -1,1 +1,2 @@
 NODE_ENV=development
+LOG_LEVEL=info

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
   },
   "dependencies": {
     "dotenv": "^16.4.5",
+    "electron-log": "^5.2.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "webpack": "^5.94.0",

--- a/src/main.js
+++ b/src/main.js
@@ -1,8 +1,7 @@
-const path = require("path");
-
-const { app, BrowserWindow } = require("electron");
-
-require("dotenv").config(); //Load environment variables
+require('dotenv').config(); //Load environment variables
+const { app, BrowserWindow } = require("electron")
+const path = require('path');
+const log = require('./util/logger')
 
 const createWindow = () => {
   let win = new BrowserWindow({
@@ -17,10 +16,11 @@ const createWindow = () => {
 
   const isDev = process.env.NODE_ENV === "development";
 
-  if (isDev) {
-    win.loadURL("http://localhost:8080"); // Load from webpack-dev-server
-  } else {
-    win.loadFile(path.join(__dirname, "../dist/index.html")); // Load the production build
+    if (isDev) {
+      win.loadURL('http://localhost:8080'); // Load from webpack-dev-server
+    } else {
+      win.loadFile(path.join(__dirname, '../dist/index.html')); // Load the production build
+    }
   }
 };
 

--- a/src/main.js
+++ b/src/main.js
@@ -21,6 +21,9 @@ const createWindow = () => {
     } else {
       win.loadFile(path.join(__dirname, '../dist/index.html')); // Load the production build
     }
+
+    log.info("Testing logging", { sample: "data", sample2: "data2"})
+    log.debug("Testing debug logging")
   }
 };
 

--- a/src/main.js
+++ b/src/main.js
@@ -25,8 +25,7 @@ const createWindow = () => {
     log.info("Testing logging", { sample: "data", sample2: "data2"})
     log.debug("Testing debug logging")
   }
-};
-
+  
 app.whenReady().then(() => {
   createWindow();
 });

--- a/src/util/logger.js
+++ b/src/util/logger.js
@@ -5,13 +5,7 @@ const log_level = process.env.LOG_LEVEL ?? 'info'
 
 log.transports.console.level = log_level
 log.transports.console.format = ({ data, level, message }) => {
-    let text;
-    if(data.length > 1) {
-        text = `${data[0]}\n${JSON.stringify(data[1], null, " ")}`
-    }
-    else {
-        text = util.format(...data)
-    }
+    const text = data.map((text) => JSON.stringify(text, null, " ")).join('\n')
     
     return [
       `*** ${message.date.toISOString().slice(11, -1)}`,

--- a/src/util/logger.js
+++ b/src/util/logger.js
@@ -1,0 +1,23 @@
+const log = require('electron-log/main')
+const util = require('node:util')
+
+const log_level = process.env.LOG_LEVEL ?? 'info'
+
+log.transports.console.level = log_level
+log.transports.console.format = ({ data, level, message }) => {
+    let text;
+    if(data.length > 1) {
+        text = `${data[0]}\n${JSON.stringify(data[1], null, " ")}`
+    }
+    else {
+        text = util.format(...data)
+    }
+    
+    return [
+      `*** ${message.date.toISOString().slice(11, -1)}`,
+      `[${level}]`,
+      text
+    ];
+  };
+  
+module.exports = log

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -30,5 +30,6 @@ module.exports = {
       template: "./public/index.html"
     })
   ],
-  target: "electron-renderer"
+  target: "electron-renderer",
+  stats: "errors-warnings"
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -3511,6 +3511,11 @@ electron-builder@^25.0.5:
     simple-update-notifier "2.0.0"
     yargs "^17.6.2"
 
+electron-log@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/electron-log/-/electron-log-5.2.0.tgz#505716926dfcf9cb3e74f42b1003be6d865bcb88"
+  integrity sha512-VjLkvaLmbP3AOGOh5Fob9M8bFU0mmeSAb5G2EoTBx+kQLf2XA/0byzjsVGBTHhikbT+m1AB27NEQUv9wX9nM8w==
+
 electron-publish@25.0.3:
   version "25.0.3"
   resolved "https://registry.npmjs.org/electron-publish/-/electron-publish-25.0.3.tgz"


### PR DESCRIPTION
## What is this PR introducing?

Uses the electron-log library to configure a logger. To use the logger, you need to add `const log = require('./util/logger')` to the imports section of the file. Log level is controlled by an ENV file.

## What components of our system does this change impact? Which core feature is this relevant to?

N/A

## Does this change depend on any other unmerged PRs? Link them here if so.

Kind of relevant to the linter PR but doesn't depend on it directly

## Pre-commit to-do list

- [x] Does this PR only contain one feature that cannot be broken up into smaller components?
- [ ] Have you written unit/integration tests for this feature?
- [ ] Have you run the linter over your code for this change?
- [ ] Have you run your changes against the testing suite?
- [x] Have you given a written explanation of the change?
- [x] Have you asked a teammate for review?

## Anything else important?

Manually tested the desired formatting works

